### PR TITLE
upgrades maven and spotbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
             <version>1.2.17</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.13</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-maven-plugin -->
         <dependency>


### PR DESCRIPTION
upgrades maven to: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin/3.10.1
upgrades spotbugs to: https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-maven-plugin/4.7.3.0